### PR TITLE
rename ansible-role-packer to packer

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 - src: geerlingguy.pip
 - src: geerlingguy.ruby
 - src: geerlingguy.docker
-- src: geerlingguy.ansible-role-packer
+- src: geerlingguy.packer
 - src: geerlingguy.java
 - src: geerlingguy.nginx
 - src: geerlingguy.elasticsearch


### PR DESCRIPTION
The name of the role at GitHub is `geerlingguy.ansible-role-packer`, but on ansible galaxy is `geerlingguy.packer`, the URL is this one
https://galaxy.ansible.com/geerlingguy/packer/

This change's already at dev branch, but most of the people use the master branch to test DevSecOps-Studio.
